### PR TITLE
fixing incorrect link to cvx diagrams

### DIFF
--- a/docs/rs/cvx03.md
+++ b/docs/rs/cvx03.md
@@ -12,7 +12,8 @@
 ## Description
 The lab is a 5-node topology with 2 servers attached to a pair of leaf switches and a single spine switch. 
 
-<div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:1,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/hellt/clabs/diagrams/cvx.drawio&quot;}"></div>
+<div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:0,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/hellt/clabs/main/diagrams/cvx.drawio&quot;}"></div>
+
 
 ## Use cases
 This is a "Cumulus Test Drive" topology designed to provide an overview of NVIDIA Cumulus Linux. It can be used together with a series of [self-paced hands-on labs](https://resource.nvidia.com/en-us-linux-lab-guide/linux-lab-guide):

--- a/docs/rs/cvx04.md
+++ b/docs/rs/cvx04.md
@@ -12,7 +12,7 @@
 The lab is a multi-node topology that consists of two racks with two dual-homed servers connected with a leaf-spine network.
 
 
-<div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:2,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/hellt/clabs/diagrams/cvx.drawio&quot;}"></div>
+<div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:1,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/hellt/clabs/main/diagrams/cvx.drawio&quot;}"></div>
 
 ## Use cases
 This is a "Cumulus In The Cloud" topology designed to demonstrate some of the advanced features of Cumulus Linux. It is based on the [original CITC demo environment](https://www.nvidia.com/en-gb/networking/network-simulation/) with the only exception being the reduced number of spine switches (2 instead of 4). The topology can be spun up fully provisioned with the following two configuration options:


### PR DESCRIPTION
The diagrams are not showing up https://clabs.netdevops.me/rs/cvx03/
this should fix that.